### PR TITLE
Update scroll helper to not be visible on default loading.

### DIFF
--- a/index.html
+++ b/index.html
@@ -337,7 +337,7 @@
       </div>
 
 
-      <div class="scroll-helper">
+      <div class="scroll-helper disappear_js">
         <a href="#top" class="scroll-helper_link"><span class="hidden">Back To Top</span></a>
       </div>
 


### PR DESCRIPTION
- The scroll helper should appear as you scroll not when you load the page.

[Ticket: #8]